### PR TITLE
Use strict version for checking whether artifact exists

### DIFF
--- a/.github/workflows/deploy-to-pantheon.yml
+++ b/.github/workflows/deploy-to-pantheon.yml
@@ -125,7 +125,7 @@ jobs:
             /build-tools-ci/scripts/set-environment
         
         - name: Check if assets exist
-          uses: xSAVIKx/artifact-exists-action@v0 
+          uses: xSAVIKx/artifact-exists-action@a9dc5938acb0f91260b31a952a914001defb642c # this is v0.2 
           id: check-artifact-existence
           with:
             name: assets


### PR DESCRIPTION
For safety, Github recommends that you use a specific commit for identifying the version of a Github action to use. I don't think it's a major issue with official GH actions but for community ones, it seems wise to be a little more cautious.