### PR TITLE
Properly delete closed multidev branches for closed PRs

### DIFF
--- a/.github/workflows/deploy-to-pantheon.yml
+++ b/.github/workflows/deploy-to-pantheon.yml
@@ -169,6 +169,6 @@ jobs:
 
             # Delete old multidev environments associated
             # with a PR that has been merged or closed.
-            terminus -n build:env:delete:pr $TERMINUS_SITE --yes
+            terminus -n build:env:delete:ci $TERMINUS_SITE --yes
        
         


### PR DESCRIPTION

According the terminus build tools docs, we need to run [build:env:delete:ci](https://github.com/pantheon-systems/terminus-build-tools-plugin#buildenvdeleteci) in order to delete all the multidev branches on Pantheon related to a closed PR, i.e. a branch prefixed with "ci-". We were incorrectly deleting ones prefixed with "pr-" so it didn't work.