### PR TITLE
Add update warning to deploy

### DIFF
--- a/.github/workflows/deploy-to-pantheon.yml
+++ b/.github/workflows/deploy-to-pantheon.yml
@@ -45,6 +45,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  warn_on_version:
+    name: "Warn that support for v0 ending"
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::warning title=\"Update now\"::Support for the download/upload-artifact@v3 action is ending in November 2024. You must update to the v1 version of this workflow."
+
   configure_env_vars:
     name: Configure environment variables
     container:

--- a/.github/workflows/deploy-to-pantheon.yml
+++ b/.github/workflows/deploy-to-pantheon.yml
@@ -49,7 +49,7 @@ jobs:
     name: "Warn that support for v0 ending"
     runs-on: ubuntu-latest
     steps:
-      - run: echo "::warning title=\"Update now\"::Support for the download/upload-artifact@v3 action is ending in November 2024. You must update to the v1 version of this workflow."
+      - run: echo "::error title=Update now::Support for the download/upload-artifact@v3 actions are ending in November 2024. This means v0 of this workflow will stop working. You must update to the v1 version of this workflow to continue using it."
 
   configure_env_vars:
     name: Configure environment variables


### PR DESCRIPTION
This adds an error annotation to the v0 version of the workflow to warn people that they must update before November to continue using this workflow.