### PR TITLE
Move to the new, official push-to-pantheon action

### DIFF
--- a/.github/workflows/deploy-to-pantheon.yml
+++ b/.github/workflows/deploy-to-pantheon.yml
@@ -17,114 +17,24 @@ on:
       TERMINUS_TOKEN:
         required: true
         description: A Pantheon machine token, as created at https://dashboard.pantheon.io/personal-settings/machine-tokens
-defaults:
-  run:
-    shell: bash
-env:
-  TZ: "/usr/share/zoneinfo/America/Los_Angeles"
-  NOTIFY: 'scripts/github/add-commit-comment {project} {sha} "Created multidev environment [{site}#{env}]({dashboard-url})." {site-url}'
-  TERM: dumb
-  # ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
-  # ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
-  # ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
-  GITHUB_TOKEN: ${{ github.token }}
-  TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
-  TEST_SITE_NAME: ${{ inputs.TERMINUS_SITE }}
-  BASH_ENV: "./bash_env.txt"
-  CI_BRANCH: ${{ github.head_ref || github.ref_name }}
-  COMMIT_SHA: ${{ github.sha }}
-  CI_BUILD_NUMBER: ${{ github.run_number }}
-  DEFAULT_SITE: ${{ inputs.TERMINUS_SITE }}
-  SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-  GITHUB_OWNER: ${{ github.repository_owner }}
-  CI_PROJECT_NAME: ${{ github.repository }}
-  PR_NUMBER: ${{github.event.pull_request.number}}
-
 concurrency:
   group: deploy-to-pantheon--${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
-  configure_env_vars:
-    name: Configure environment variables
-    container:
-      image: quay.io/pantheon-public/build-tools-ci:6.x
-      options: --user root
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: install gh cli
-        run: |
-          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-          && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-          && sudo apt update \
-          && sudo apt install gh -y
-      - name: Get default branch
-        id: get-origin-default-branch
-        run: |
-          export BRANCH=`gh api /repos/${{ github.repository }} --jq ".default_branch"`
-          echo "default_branch=${BRANCH}" >> "$GITHUB_OUTPUT"
-
-      - name: Cache bash_env.txt
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-bash-env
-        with:
-          path: bash_env.txt
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}-${{ github.run_attempt }}
-
-      # Set TERMINUS_ENV and related environment variables.
-      # https://github.com/pantheon-systems/docker-build-tools-ci/blob/6.x/scripts/set-environment
-      - name: setup-environment-vars
-        run: |
-          export CI_PROJECT_REPONAME=`curl -u "${GITHUB_OWNER}:${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github.groot-preview+json" \
-            "https://api.github.com/repos/${CI_PROJECT_NAME}/commits/${COMMIT_SHA}/pulls" | \
-            python3 -c "import sys, json; print(json.load(sys.stdin)[0]['base']['repo']['name'])"`
-          export CI_PROJECT_USERNAME=$GITHUB_REPOSITORY_OWNER
-          export DEFAULT_BRANCH='${{ steps.get-origin-default-branch.outputs.default_branch}}'
-          /build-tools-ci/scripts/set-environment
-          GITHUB_WORKFLOW_URL=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-          echo "export CI_BUILD_URL='${GITHUB_WORKFLOW_URL}'" >> $BASH_ENV
-          echo "export CI_NODE_INDEX=0" >> $BASH_ENV
-          echo "export CI_REPOSITORY_URL='https://github.com/${GITHUB_REPOSITORY}'" >> $BASH_ENV
-          echo "export ARTIFACTS_DIR_URL='${GITHUB_WORKFLOW_URL}/#artifacts'" >> $BASH_ENV
 # important note: deploy_to_pantheon will push EVERYTHING in the repo directory other than the .git directory, i.e.
 # it will not respect .gitignore
   deploy_to_pantheon:
       name: "Deploy to Pantheon"
-      container:
-        image: quay.io/pantheon-public/build-tools-ci:6.x
-        options: --user root
       runs-on: ubuntu-latest
-      needs: [configure_env_vars]
+      permissions:
+        deployments: write
+        contents: read
+        pull-requests: read
+
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
-
-        - name: Cache bash_env.txt
-          uses: actions/cache@v4
-          env:
-            cache-name: cache-bash-env
-          with:
-            path: bash_env.txt
-            key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}-${{ github.run_attempt }}
-            restore-keys: |
-              ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}-
-              ${{ runner.os }}-build-${{ env.cache-name }}-
-              ${{ runner.os }}-build-
-              ${{ runner.os }}-
-        # Set TERMINUS_ENV and related environment variables.
-        # https://github.com/pantheon-systems/docker-build-tools-ci/blob/6.x/scripts/set-environment
-        - name: setup-environment-vars
-          run: |
-            source $BASH_ENV
-            /build-tools-ci/scripts/set-environment
         
         - name: Check if assets exist
           uses: softwareforgood/check-artifact-v4-existence@v0
@@ -141,35 +51,10 @@ jobs:
 
         # Deploy to Pantheon
         - name: deploy to Pantheon
-          run: |
-            echo "$SSH_PRIVATE_KEY" > ../private.key
-            chmod 600 ../private.key
-            eval `ssh-agent -s`
-            ssh-add ../private.key
-            source $BASH_ENV
-
-            terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
-
-            if [[ $CI_BRANCH != $DEFAULT_BRANCH ]]
-            then
-                # Create a new multidev environment (or push to an existing one)
-                terminus -n build:env:create "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes
-            else
-                # Push to the dev environment
-                terminus -n build:env:push "$TERMINUS_SITE.dev" --yes --message "Build"
-            fi
-
-            # Run update-db to ensure that the cloned database is updated for the new code.
-            terminus -n wp $TERMINUS_SITE.$TERMINUS_ENV -- core update-db
-
-            # Clear the site environment's cache
-            terminus -n env:clear-cache "$TERMINUS_SITE.$TERMINUS_ENV"
-
-            # Ensure secrets are set
-            terminus -n secrets:set "$TERMINUS_SITE.$TERMINUS_ENV" token "$GITHUB_TOKEN" --file='github-secrets.json' --clear --skip-if-empty
-
-            # Delete old multidev environments associated
-            # with a PR that has been merged or closed.
-            terminus -n build:env:delete:pr $TERMINUS_SITE --yes
+          uses: pantheon-systems/push-to-pantheon@0.5.0
+          with:
+            ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+            machine_token: ${{ secrets.TERMINUS_TOKEN }}
+            site: ${{ inputs.TERMINUS_SITE }}
        
         


### PR DESCRIPTION
Pantheon has [announced](https://pantheon.io/blog/github-action) that they now have an official[ push to pantheon Github Action](https://github.com/pantheon-systems/push-to-pantheon). There's no need to support our own action and the new one, while still a pre 1.0 release, is already more feature filled and boatload faster.

This has been tested on an internal repo at https://github.com/softwareforgood/softwareforgood.com/pull/636 and it's run successfully.

I propose we merge this and cut a new major version release for it; that way no repos automatically move to the new workflow.

