### PR TITLE
Revert "Bump pantheon-systems/push-to-pantheon from 0.8.0 to 0.9.0"

### DIFF
--- a/.github/workflows/deploy-to-pantheon.yml
+++ b/.github/workflows/deploy-to-pantheon.yml
@@ -51,7 +51,7 @@ jobs:
 
         # Deploy to Pantheon
         - name: deploy to Pantheon
-          uses: pantheon-systems/push-to-pantheon@0.9.0
+          uses: pantheon-systems/push-to-pantheon@0.8.0
           with:
             ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
             machine_token: ${{ secrets.TERMINUS_TOKEN }}


### PR DESCRIPTION
Reverts softwareforgood/reusable-github-workflows#52

For unclear reasons, the upgraded pantheon workflow is breaking. I don't have time to look into it now so let's just revert to an older version.